### PR TITLE
The error message “Domain error in arguments” could be more informative

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1030,7 +1030,7 @@ class rv_generic(object):
         args, loc, scale, size = self._parse_args_rvs(*args, **kwds)
         cond = logical_and(self._argcheck(*args), (scale >= 0))
         if not np.all(cond):
-            raise ValueError("Domain error in arguments.")
+            raise ValueError("Domain error in arguments:shape parameters should be positive and scale should >=0.")
 
         if np.all(scale == 0):
             return loc*ones(size, 'd')


### PR DESCRIPTION
The error message “`Domain error in arguments`” seems too general to be informative.

```
C:\ProgramData\Anaconda3\lib\site-packages\scipy\stats\_distn_infrastructure.py in rvs(self, *args, **kwds)
    938         cond = logical_and(self._argcheck(*args), (scale >= 0))
    939         if not np.all(cond):
--> 940             raise ValueError("Domain error in arguments.")
    941 
    942         if np.all(scale == 0):
```


After reading the source, I believe that the expected behavior is that shape parameters should be positive and scale should >=0. Adding this information to the error message should be more user-friendly.

Expected error message:
`Domain error in arguments: shape parameters should be positive and scale should >=0.`
